### PR TITLE
Force a path to be set on session cookies

### DIFF
--- a/router.go
+++ b/router.go
@@ -77,6 +77,10 @@ func New(opts ...Option) *App {
 	cookieStore.Options.HttpOnly = true
 	cookieStore.Options.SameSite = http.SameSiteLaxMode
 
+	// Force a consistent path for browsers that are sensitive to this during
+	// AJAX requests.
+	cookieStore.Options.Path = "/"
+
 	// TODO:
 	//
 	// Here we're assuming the reload value means that we're not in


### PR DESCRIPTION
Forces a path to be set on session cookies to prevent a rare error that occurs with older browsers failing to set cookies on AJAX requests due to a missing or incorrect path.