### PR TITLE
cookie: extend default max age

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"html/template"
 	"log"
+	"strings"
 
 	"github.com/bentranter/go-seatbelt"
 )
 
 func handle(c seatbelt.Context) error {
-	return c.Render("index", nil)
+	c.Session().Put("key", "value")
+	return c.Render("home/index", nil)
 }
 
 func products(c seatbelt.Context) error {
@@ -36,6 +39,9 @@ func redirector(c seatbelt.Context) error {
 func main() {
 	app := seatbelt.New(seatbelt.Option{
 		TemplateDir: "testdata",
+		Funcs: template.FuncMap{
+			"lower": strings.ToLower,
+		},
 	})
 
 	app.Get("/", handle)

--- a/router.go
+++ b/router.go
@@ -84,6 +84,10 @@ func New(opts ...Option) *App {
 	// AJAX requests.
 	cookieStore.Options.Path = "/"
 
+	// Default to one year for new cookies, since some browsers don't set
+	// their cookies with the same defaults.
+	cookieStore.Options.MaxAge = 86400 * 365
+
 	// TODO:
 	//
 	// Here we're assuming the reload value means that we're not in


### PR DESCRIPTION
Extends the default max age for browsers with bad defaults, or devices with misbehaving clocks. Probably won't actually fix anything, but worth a try.