### PR TITLE
session: improve session and flash messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.16.x, 1.17.x ]
 
     steps:
     - name: Install Go

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,15 @@
 module github.com/bentranter/go-seatbelt
 
-go 1.16
+go 1.17
 
 require (
 	github.com/go-chi/chi v1.5.4
 	github.com/gorilla/csrf v1.7.0
 	github.com/gorilla/sessions v1.2.1
 	github.com/mitchellh/mapstructure v1.4.1
+)
+
+require (
+	github.com/gorilla/securecookie v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 )

--- a/render.go
+++ b/render.go
@@ -209,6 +209,13 @@ func (r *Renderer) HTML(w io.Writer, req *http.Request, name string, data interf
 		opt = o
 	}
 
+	// If data is nil, it'll cause panics when trying to render a template that
+	// attempts to access a variable that doesn't exist. To get around that,
+	// ensure that data is always at least an empty map[string]interface{}.
+	if data == nil {
+		data = make(map[string]interface{})
+	}
+
 	if r.reload {
 		if err := r.parseTemplates(); err != nil {
 			return err


### PR DESCRIPTION
* Improves the flash messages interface and methods to use a map for the data model instead of a slice.
* Adds a `Del` method to delete values without deleting the entire map. This provides a better experience than using `Put` to set a key to a zero value, which causes checks for existence against the session map to return `true`, when `false` is easier to handle.
* Protects the HTML renderer again nil maps
* Adds an overrideable global error handler.