### PR TITLE
session: register gob encoder for flashes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,12 +9,7 @@ import (
 )
 
 func handle(c seatbelt.Context) error {
-	c.Session().Put("key", "value")
 	return c.Render("home/index", nil)
-}
-
-func products(c seatbelt.Context) error {
-	return c.Render("products/show", nil)
 }
 
 type product struct {
@@ -23,13 +18,18 @@ type product struct {
 }
 
 func newProduct(c seatbelt.Context) error {
+	return c.Render("products/new", nil)
+}
+
+func createProduct(c seatbelt.Context) error {
 	p := &product{}
 
 	if err := c.Params(p); err != nil {
 		return err
 	}
 
-	return c.Render("products/new", p)
+	c.Session().Flash("notice", "Successfully added product "+p.Name)
+	return c.Redirect("/")
 }
 
 func redirector(c seatbelt.Context) error {
@@ -45,8 +45,8 @@ func main() {
 	})
 
 	app.Get("/", handle)
-	app.Get("/products", products)
-	app.Post("/products", newProduct)
+	app.Get("/products/new", newProduct)
+	app.Post("/products", createProduct)
 	app.Get("/redirect", redirector)
 
 	log.Fatalln(app.Start(":3000"))

--- a/context_session.go
+++ b/context_session.go
@@ -126,14 +126,14 @@ func (s *session) Flash(key string, value interface{}) {
 	flashMap[key] = value
 
 	session.AddFlash(flashMap)
-	session.Save(s.r, s.w)
+
+	if err := session.Save(s.r, s.w); err != nil {
+		fmt.Printf("seatbelt: failed to save session in Flash(%s, %v): %s\n", key, value, err.Error())
+	}
 }
 
 // GetFlash returns the flash message with the given key, if one exists. If
 // one does not, the returned boolean will be false, otherwise it is true.
-//
-// TODO(maybe?): GetFlash will **not** clear the flashes on subsequent
-// requests. You must call `Flashes` to clear the flashes on the next request.
 func (s *session) GetFlash(key string) (interface{}, bool) {
 	session := s.session()
 	flashes := session.Flashes()
@@ -165,7 +165,10 @@ func (s *session) Flashes() map[string]interface{} {
 		return nil
 	}
 
-	session.Save(s.r, s.w)
+	if err := session.Save(s.r, s.w); err != nil {
+		fmt.Printf("seatbelt: failed to save session in Flashes(): %s\n", err.Error())
+	}
+
 	return flashMap
 }
 

--- a/router.go
+++ b/router.go
@@ -1,6 +1,7 @@
 package seatbelt
 
 import (
+	"encoding/gob"
 	"encoding/hex"
 	"fmt"
 	"html/template"
@@ -38,7 +39,7 @@ type App struct {
 }
 
 // MiddlewareFunc is the type alias for Seatbelt middleware.
-type MiddlewareFunc func(func(Context) error) func(Context) error
+type MiddlewareFunc func(fn func(ctx Context) error) func(Context) error
 
 // An Option is used to configure a Seatbelt application.
 type Option struct {
@@ -66,6 +67,10 @@ func New(opts ...Option) *App {
 	}
 
 	opt.setDefaults()
+
+	// Register the encoding for map[string]interface{} with gob such that we
+	// can successfully save flash messages in the session.
+	gob.Register(map[string]interface{}{})
 
 	signingKey, err := hex.DecodeString(opt.SigningKey)
 	if err != nil {

--- a/testdata/home/index.html
+++ b/testdata/home/index.html
@@ -3,5 +3,7 @@
 {{ define "main" }}
   {{ template "home/partial" . }}
   <h1>Home</h1>
+  {{ flashes }}
+  <a href="/products/new">Add product</a>
   <form>{{ csrf }}</form>
 {{ end }}

--- a/testdata/products/new.html
+++ b/testdata/products/new.html
@@ -1,0 +1,12 @@
+{{ define "title" }}New Product{{ end }}
+
+{{ define "main" }}
+  {{ flashes }}
+  <h1>Add product</h1>
+  <form action="/products" method="POST">
+    {{ csrf }}
+    <input type="text" name="name" placeholder="Name"/>
+    <input type="number" name="price" placeholder="Price"/>
+    <input type="submit" value="Submit"/>
+  </form>
+{{ end }}


### PR DESCRIPTION
Registers the gob encoder so that flashes are saved properly. Also updates the example code to include flashes, and improves the function signature of the middleware func so that autocompletion tools suggest something more useable.